### PR TITLE
all'apertura del link ad una nuova scheda il popup non funzionava

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
 				</p>
 				<p>
 					Cerca sulla mappa i Digital Champions più vicini a te, clicca sulle icone, e manda loro un tweet di segnalazione con
-					un link <a class="trigger" href="pdfreaders">a questo appello</a>.
+					un link <a class="trigger" href="#pdfreaders">a questo appello</a>.
 				</p>
 			</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 				<h3>Campagne Passate</h3>
 
 				<p>
-					<a class="trigger" href="dfd2015">Marzo 2015: Document Freedom Day</a>
+					<a class="trigger" href="#dfd2015">Marzo 2015: Document Freedom Day</a>
 				</p>
 			</div>
 		</div>

--- a/js/dac.js
+++ b/js/dac.js
@@ -47,7 +47,7 @@ function initMap () {
 
 $(document).ready(function(){
 	$('.trigger').click(function () {
-		var name = $(this).attr('href');
+		var name = $(this).attr('href').replace('#', '');
 		$('#' + name).modal('show');
 		window.location.hash = name;
 		return false;


### PR DESCRIPTION
Se si clicca con la rotella su "a questo appello" viene aperta una nuova scheda con l'errore 404.
Questo piccolo fix risolve il problema.
